### PR TITLE
Pan gesture callback fix

### DIFF
--- a/Source/Charts/Charts/BarLineChartViewBase.swift
+++ b/Source/Charts/Charts/BarLineChartViewBase.swift
@@ -790,8 +790,6 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
                 }
                 
                 _isDragging = false
-                
-                delegate?.chartViewDidEndPanning?(self)
             }
             
             if _outerScrollView !== nil
@@ -799,6 +797,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
                 _outerScrollView?.nsuiIsScrollEnabled = true
                 _outerScrollView = nil
             }
+            delegate?.chartViewDidEndPanning?(self)
         }
     }
     


### PR DESCRIPTION
The pan gesture callback to the delegate for some reason wasn't called when it was in highlighting mode (the other mode would be to move the graph when zoomed in, which we don't use).
With this change the delegate is always called when the gesture is ended/cancelled.